### PR TITLE
fix: 替换ExpressionStatement为JSXElement

### DIFF
--- a/packages/arco-markdown-loader/src/index.ts
+++ b/packages/arco-markdown-loader/src/index.ts
@@ -17,6 +17,7 @@ import {
   JSXIdentifier,
   JSXText,
   JSXAttribute,
+  ExpressionStatement,
 } from '@babel/types';
 
 import marked from './parser/marked';
@@ -187,8 +188,8 @@ function loaderForArcoComponentDoc(
           : `<>
             <div className="ac-toolbar">${ButtonJSX}</div>
             <Component />${DrawerJSX}</>`;
-
-        const element = babelParse(componentJsx).program.body[0];
+        const expressionStatement = babelParse(componentJsx).program.body[0] as ExpressionStatement
+        const element = expressionStatement.expression
         _path.replaceWith(element);
         _path.stop();
       }


### PR DESCRIPTION
<!--
  Thanks so much for your PR and contribution.
  
  Before submitting, please make sure to follow the Pull Request Guidelines: https://github.com/arco-design/arco-cli/blob/master/CONTRIBUTING.md
-->

<!-- Put an `x` in "[ ]" to check a box) -->

## Types of changes

<!-- What types of changes does this PR introduce -->
- [ ] New feature
- [x] Bug fix
- [ ] Documentation change
- [ ] Coding style change
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Test cases
- [ ] Continuous integration
- [ ] Typescript definition change
- [ ] Breaking change

## Background and context

> 背景

现在是替换`%%content%%`，当尝试自动在生成的PROPS前插入时，会出现“;”分号。

> 出现问题

现有情况下，replaceWith的是ExpressionStatement，当改为insertBefore ExpressionStatement。生成的code中会出现“;” 分号
insertBefore JSXElement则表现正确
![image](https://user-images.githubusercontent.com/44751363/183272725-d0bfc423-255f-4bf5-ba71-363edda049c3.png)

<!-- Explain what problem does the PR solve -->
<!-- Link to related open issues if applicable -->

## Solution

<!-- Describe how the problem is fixed in detail -->

## How is the change tested?

<!-- Unit tests should be added/updated for bug fixes and new features, if applicable -->
<!-- Please describe how you tested the change. E.g. Creating/updating unit tests or attaching a screenshot of how it works with your change -->

## Changelog

| Changelog(CN) | Changelog(EN) | Related issues | 
| ------------- | ------------- | -------------- |

## Checklist:

- [ ] Provide changelog for relevant changes (e.g. bug fixes and new features) if applicable.
- [ ] Changes are submitted to the appropriate branch (e.g. features should be submitted to `feature` branch and others should be submitted to `master` branch)

## Other information

<!-- Please describe what other information that should be taken care of. E.g. describe the impact if introduce a breaking change -->
